### PR TITLE
broadcast name instead of id on death

### DIFF
--- a/DPSMate/DPSMate_DataBuilder.lua
+++ b/DPSMate/DPSMate_DataBuilder.lua
@@ -1912,7 +1912,7 @@ function DPSMate.DB:UnregisterDeath(target)
 			DPSMateDeaths[cat][target][1]["i"][2]=GameTime_GT()
 			if cat==1 and DPSMate.Parser.TargetParty[DPSMate:GetUserById(target)] then 
 				p = DPSMateDeaths[cat][target][1][1]
-				DPSMate:Broadcast(4, target, DPSMate:GetUserById(p[1]), DPSMate:GetAbilityById(p[2]), p[3]) 
+				DPSMate:Broadcast(4, DPSMate:GetUserById(target), DPSMate:GetUserById(p[1]), DPSMate:GetAbilityById(p[2]), p[3]) 
 			end
 		end
 	end


### PR DESCRIPTION
It was reporting "6 was killed by..." instead of saying the name.