### PR TITLE
Fix init error with combatlog extender, use traffic shaping to alleviate slowdowns

### DIFF
--- a/DPSMate/DPSMate.lua
+++ b/DPSMate/DPSMate.lua
@@ -107,7 +107,9 @@ local strsub = strsub
 local tonumber = tonumber
 local getn = getn
 local tconcat = table.concat
-local SendChatMessage = ChatThrottleLib.SendChatMessage
+local SendChatMessage = function(prio, prefix, text, chattype, language, destination) 
+	ChatThrottleLib:SendChatMessage(prio, prefix, text, chattype, language, destination) 
+end
 
 
 -- Begin functions

--- a/DPSMate/DPSMate.lua
+++ b/DPSMate/DPSMate.lua
@@ -1,6 +1,6 @@
 -- Global Variables
 DPSMate = {}
-DPSMate.VERSION = 127
+DPSMate.VERSION = 128
 DPSMate.LOCALE = GetLocale()
 DPSMate.SYNCVERSION = DPSMate.VERSION..DPSMate.LOCALE
 DPSMate.Parser = CreateFrame("Frame", nil, UIParent)
@@ -107,6 +107,7 @@ local strsub = strsub
 local tonumber = tonumber
 local getn = getn
 local tconcat = table.concat
+local SendChatMessage = ChatThrottleLib.SendChatMessage
 
 
 -- Begin functions
@@ -661,24 +662,24 @@ function DPSMate:Broadcast(type, who, what, with, value, failtype)
 				ch = "RAID_WARNING"
 			end
 			if DPSMateSettings["bccd"] and type == 1 then
-				SendChatMessage(self.L["bccdo"](who, what), ch, nil, nil)
+				SendChatMessage("BULK", "DPSMateChat", self.L["bccdo"](who, what), ch, nil, nil)
 				return
 			elseif DPSMateSettings["bccd"] and type == 6 then
-				SendChatMessage(self.L["bccdt"](who, what), ch, nil, nil)
+				SendChatMessage("BULK", "DPSMateChat", self.L["bccdt"](who, what), ch, nil, nil)
 				return
 			elseif DPSMateSettings["bcress"] and type == 2 then
-				SendChatMessage(self.L["bcress"](who, what), ch, nil, nil)
+				SendChatMessage("BULK", "DPSMateChat", self.L["bcress"](who, what), ch, nil, nil)
 				return
 			elseif DPSMateSettings["bckb"] and type == 4 then
-				SendChatMessage(self.L["bckb"](who, what, with, value), ch, nil, nil)
+				SendChatMessage("BULK", "DPSMateChat", self.L["bckb"](who, what, with, value), ch, nil, nil)
 				return
 			elseif DPSMateSettings["bcfail"] and type == 3 then
 				if failtype == 1 then
-					SendChatMessage(self.L["bcfailo"](what, who, value, with), ch, nil, nil)
+					SendChatMessage("BULK", "DPSMateChat", self.L["bcfailo"](what, who, value, with), ch, nil, nil)
 				elseif failtype == 3 then
-					SendChatMessage(self.L["bcfailt"](who, with), ch, nil, nil)
+					SendChatMessage("BULK", "DPSMateChat", self.L["bcfailt"](who, with), ch, nil, nil)
 				else
-					SendChatMessage(self.L["bcfailth"](who, value, with, what), ch, nil, nil)
+					SendChatMessage("BULK", "DPSMateChat", self.L["bcfailth"](who, value, with, what), ch, nil, nil)
 				end
 				return
 			end

--- a/DPSMate/DPSMate.toc
+++ b/DPSMate/DPSMate.toc
@@ -9,6 +9,7 @@
 libs\AceLibrary\AceLibrary.lua
 libs\Dewdrop-2.0\Dewdrop-2.0.lua
 libs\GraphLib\Graph-1.0\Graph-1.0.lua
+libs\ChatThrottleLib.lua
 enUS\Babble-Spell-2.3.lua
 enUS\Babble-Boss-2.3.lua
 enUS\NPCDB-1.0.lua

--- a/DPSMate/DPSMate_DataBuilder.lua
+++ b/DPSMate/DPSMate_DataBuilder.lua
@@ -1,5 +1,6 @@
 -- Events
 DPSMate.DB:RegisterEvent("VARIABLES_LOADED")
+DPSMate.DB:RegisterEvent("PLAYER_LOGIN")
 DPSMate.DB:RegisterEvent("PLAYER_REGEN_DISABLED")
 DPSMate.DB:RegisterEvent("PLAYER_REGEN_ENABLED")
 DPSMate.DB:RegisterEvent("PLAYER_AURAS_CHANGED")
@@ -158,6 +159,7 @@ local UnitIsPlayer = UnitIsPlayer
 local UnitIsDead = UnitIsDead
 local UnitBuff = UnitBuff
 local UnitInRaid = UnitInRaid
+local SendAddonMessage = ChatThrottleLib.SendAddonMessage
 local pairs = pairs
 local floor = floor
 local UnitIsConnected = UnitIsConnected
@@ -657,6 +659,54 @@ DPSMate.DB.VARIABLES_LOADED = function()
 	end
 end
 
+DPSMate.DB.PLAYER_LOGIN = function()
+	if GetCVar("CombatLogPeriodicSpells") then 
+		SetCVar("CombatLogPeriodicSpells", 1) 
+	else 
+		RegisterCVar("CombatLogPeriodicSpells", 1) 
+	end
+	if GetCVar("CombatLogRangeParty") then 
+		SetCVar("CombatLogRangeParty", 200) 
+	else 
+		RegisterCVar("CombatLogRangeParty", 200) 
+	end
+	if GetCVar("CombatLogRangePartyPet") then 
+		SetCVar("CombatLogRangePartyPet", 200) 
+	else 
+		RegisterCVar("CombatLogRangePartyPet", 200) 
+	end
+	if GetCVar("CombatLogRangeFriendlyPlayers") then 
+		SetCVar("CombatLogRangeFriendlyPlayers", 200) 
+	else 
+		RegisterCVar("CombatLogRangeFriendlyPlayers", 200) 
+	end
+	if GetCVar("CombatLogRangeFriendlyPlayersPets") then 
+		SetCVar("CombatLogRangeFriendlyPlayersPets", 200) 
+	else 
+		RegisterCVar("CombatLogRangeFriendlyPlayersPets", 200) 
+	end
+	if GetCVar("CombatLogRangeHostilePlayers") then 
+		SetCVar("CombatLogRangeHostilePlayers", 200) 
+	else 
+		RegisterCVar("CombatLogRangeHostilePlayers", 200) 
+	end
+	if GetCVar("CombatLogRangeHostilePlayersPets") then 
+		SetCVar("CombatLogRangeHostilePlayersPets", 200) 
+	else 
+		RegisterCVar("CombatLogRangeHostilePlayersPets", 200) 
+	end
+	if GetCVar("CombatLogRangeCreature") then 
+		SetCVar("CombatLogRangeCreature", 200) 
+	else 
+		RegisterCVar("CombatLogRangeCreature", 200) 
+	end
+	if GetCVar("CombatDeathLogRange") then 
+		SetCVar("CombatDeathLogRange", 200) 
+	else 
+		RegisterCVar("CombatDeathLogRange", 200) 
+	end
+end
+
 DPSMate.DB.PLAYER_REGEN_DISABLED = function()
 	if DPSMateSettings["hideincombat"] then
 		for _, val in pairs(DPSMateSettings["windows"]) do
@@ -904,7 +954,7 @@ function DPSMate.DB:UpdateThreat()
 		end
 		if str then
 			self.KTMHOOK = {}
-			SendAddonMessage("KLHTMHOOK", str, "RAID")
+			SendAddonMessage("ALERT", "KLHTMHOOK", str, "RAID")
 		end
 	end
 end

--- a/DPSMate/DPSMate_DataBuilder.lua
+++ b/DPSMate/DPSMate_DataBuilder.lua
@@ -159,11 +159,13 @@ local UnitIsPlayer = UnitIsPlayer
 local UnitIsDead = UnitIsDead
 local UnitBuff = UnitBuff
 local UnitInRaid = UnitInRaid
-local SendAddonMessage = ChatThrottleLib.SendAddonMessage
 local pairs = pairs
 local floor = floor
 local UnitIsConnected = UnitIsConnected
 local time, path, gen
+local SendAddonMessage = function(prio, prefix, text, chattype)
+	ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype)
+end
 
 DPSMate.DB.windfuryab = {
 	["Windfury Weapon"] = true,

--- a/DPSMate/DPSMate_Options.lua
+++ b/DPSMate/DPSMate_Options.lua
@@ -387,7 +387,9 @@ local tinsert = table.insert
 local tremove = tremove
 local strformat = string.format
 local strgfind = string.gfind
-local SendChatMessage = ChatThrottleLib.SendChatMessage
+local SendChatMessage = function(prio, prefix, text, chattype, language, destination) 
+	ChatThrottleLib:SendChatMessage(prio, prefix, text, chattype, language, destination) 
+end
 
 -- Begin Functions
 

--- a/DPSMate/DPSMate_Options.lua
+++ b/DPSMate/DPSMate_Options.lua
@@ -387,6 +387,7 @@ local tinsert = table.insert
 local tremove = tremove
 local strformat = string.format
 local strgfind = string.gfind
+local SendChatMessage = ChatThrottleLib.SendChatMessage
 
 -- Begin Functions
 
@@ -1439,13 +1440,13 @@ function DPSMate.Options:Report()
 	else
 		chn = "CHANNEL"; index = GetChannelName(channel)
 	end
-	SendChatMessage(DPSMate.L["name"].." - "..DPSMate.L["reportfor"]..DPSMate:GetModeName(DPSMate_Report.PaKey or 1).." - ".._G("DPSMate_"..DPSMateSettings["windows"][DPSMate_Report.PaKey or 1]["name"].."_Head_Font"):GetText().." - "..b[1]..b[2], chn, nil, index)
+	SendChatMessage("BULK", "DPSMateChat", DPSMate.L["name"].." - "..DPSMate.L["reportfor"]..DPSMate:GetModeName(DPSMate_Report.PaKey or 1).." - ".._G("DPSMate_"..DPSMateSettings["windows"][DPSMate_Report.PaKey or 1]["name"].."_Head_Font"):GetText().." - "..b[1]..b[2], chn, nil, index)
 	for i=1, DPSMate_Report_Lines:GetValue() do
 		if (not value[i] or value[i] == 0) then break end
 		if DPSMateSettings["reportdelay"] then
 			tinsert(DPSMate.DelayMsg, {i..". "..name[i].." -"..value[i], chn, index})
 		else
-			SendChatMessage(i..". "..name[i].." -"..value[i], chn, nil, index)
+			SendChatMessage("BULK", "DPSMateChat", i..". "..name[i].." -"..value[i], chn, nil, index)
 		end
 	end
 	DPSMate_Report:Hide()
@@ -1476,7 +1477,7 @@ function DPSMate.Options:ReportUserDetails(obj, channel, name)
 	if b~=0 then
 		bb = " - "..strformat("%.2f", b)
 	end
-	SendChatMessage(DPSMate.L["name"].." - "..DPSMate.L["reportof"].." "..user.."'s ".._G("DPSMate_"..DPSMateSettings["windows"][Key]["name"].."_Head_Font"):GetText().." - "..DPSMate:GetModeName(Key)..bb, chn, nil, index)
+	SendChatMessage("BULK", "DPSMateChat", DPSMate.L["name"].." - "..DPSMate.L["reportof"].." "..user.."'s ".._G("DPSMate_"..DPSMateSettings["windows"][Key]["name"].."_Head_Font"):GetText().." - "..DPSMate:GetModeName(Key)..bb, chn, nil, index)
 	for i=1, 10 do
 		if (not a[i]) then break end
 		local p
@@ -1489,13 +1490,13 @@ function DPSMate.Options:ReportUserDetails(obj, channel, name)
 				if DPSMateSettings["reportdelay"] then
 					tinsert(DPSMate.DelayMsg, {i..". |cFF8cff80"..DPSMate:GetAbilityById(a[i]).." => ".."+"..c[i][1]..type.."|r", chn, index})
 				else
-					SendChatMessage(i..". |cFF8cff80"..DPSMate:GetAbilityById(a[i]).." => ".."+"..c[i][1]..type.."|r", chn, nil, index)
+					SendChatMessage("BULK", "DPSMateChat", i..". |cFF8cff80"..DPSMate:GetAbilityById(a[i]).." => ".."+"..c[i][1]..type.."|r", chn, nil, index)
 				end
 			else
 				if DPSMateSettings["reportdelay"] then
 					tinsert(DPSMate.DelayMsg, {i..". |cFFFF8080"..DPSMate:GetAbilityById(a[i]).." => ".."-"..c[i][1]..type.."|r", chn, index})
 				else
-					SendChatMessage(i..". |cFFFF8080"..DPSMate:GetAbilityById(a[i]).." => ".."-"..c[i][1]..type.."|r", chn, nil, index)
+					SendChatMessage("BULK", "DPSMateChat", i..". |cFFFF8080"..DPSMate:GetAbilityById(a[i]).." => ".."-"..c[i][1]..type.."|r", chn, nil, index)
 				end
 			end
 		else
@@ -1503,20 +1504,20 @@ function DPSMate.Options:ReportUserDetails(obj, channel, name)
 				if DPSMateSettings["reportdelay"] then
 					tinsert(DPSMate.DelayMsg, {i..". "..DPSMate.Modules.Fails:Type(a[i]).." - "..p, chn, index})
 				else
-					SendChatMessage(i..". "..DPSMate.Modules.Fails:Type(a[i]).." - "..p, chn, nil, index)
+					SendChatMessage("BULK", "DPSMateChat", i..". "..DPSMate.Modules.Fails:Type(a[i]).." - "..p, chn, nil, index)
 				end
 			else
 				if DPSMate:TContains(AbilityModes, DPSMateSettings["windows"][Key]["CurMode"]) then
 					if DPSMateSettings["reportdelay"] then
 						tinsert(DPSMate.DelayMsg, {i..". "..DPSMate:GetAbilityById(a[i]).." - "..p, chn, index})
 					else
-						SendChatMessage(i..". "..DPSMate:GetAbilityById(a[i]).." - "..p, chn, nil, index)
+						SendChatMessage("BULK", "DPSMateChat", i..". "..DPSMate:GetAbilityById(a[i]).." - "..p, chn, nil, index)
 					end
 				else
 					if DPSMateSettings["reportdelay"] then
 						tinsert(DPSMate.DelayMsg, {i..". "..DPSMate:GetUserById(a[i]).." - "..p, chn, index})
 					else
-						SendChatMessage(i..". "..DPSMate:GetUserById(a[i]).." - "..p, chn, nil, index)
+						SendChatMessage("BULK", "DPSMateChat", i..". "..DPSMate:GetUserById(a[i]).." - "..p, chn, nil, index)
 					end
 				end
 			end
@@ -2136,7 +2137,7 @@ function DPSMate.Options:OnUpdate()
 	if DPSMateSettings["reportdelay"] and DPSMate.DelayMsg[1] then
 		reportuptime = reportuptime + arg1
 		if reportuptime>reportdelay then
-			SendChatMessage(DPSMate.DelayMsg[1][1], DPSMate.DelayMsg[1][2], nil, DPSMate.DelayMsg[1][3])
+			SendChatMessage("BULK", "DPSMateChat", DPSMate.DelayMsg[1][1], DPSMate.DelayMsg[1][2], nil, DPSMate.DelayMsg[1][3])
 			tremove(DPSMate.DelayMsg, 1)
 			reportuptime = 0
 		end

--- a/DPSMate/DPSMate_Sync.lua
+++ b/DPSMate/DPSMate_Sync.lua
@@ -14,7 +14,7 @@ local strgfind = string.gfind
 local tinsert = table.insert
 local tremove = table.remove
 local tnbr = tonumber
-local SDM = SendAddonMessage
+local SDM = ChatThrottleLib.SendAddonMessage
 local func = function(c) tinsert(t,c) end
 local LastMouseover = nil
 local DB = DPSMate.DB
@@ -141,7 +141,7 @@ function DPSMate.Sync:OnUpdate()
 			iterator, time = 1, 0
 		end
 		if Buffer[co] and updater>0.1 and not UnitAffectingCombat("player") then
-			SDM(Buffer[co][1]..sKey, Buffer[co][2], "RAID")
+			SDM("NORMAL", Buffer[co][1]..sKey, Buffer[co][2], "RAID")
 			Buffer[co] = nil
 			co = co + 1
 			updater = 0
@@ -182,7 +182,7 @@ end
 
 function DPSMate.Sync:Vote()
 	DPSMate_Vote:Hide()
-	SDM("DPSMate_Vote"..DPSMate.SYNCVERSION, nil, "RAID")
+	SDM("BULK", "DPSMate_Vote"..DPSMate.SYNCVERSION, nil, "RAID")
 end
 
 local voteCount = 1
@@ -191,7 +191,7 @@ local abort = 0
 function DPSMate.Sync:StartVote()
 	if not voteStarter then
 		self.synckey = player..(random(1,1000))
-		SDM("DPSMate_StartVote"..DPSMate.SYNCVERSION, nil, "RAID")
+		SDM("BULK", "DPSMate_StartVote"..DPSMate.SYNCVERSION, nil, "RAID")
 		voteStarter = true
 		participants = 1
 	else
@@ -203,7 +203,7 @@ function DPSMate.Sync:CountVote()
 	if voteStarter then
 		voteCount=voteCount+1
 		if voteCount >= (participants/2) then
-			SDM("DPSMate_VoteSuccess"..DPSMate.SYNCVERSION, self.synckey, "RAID")
+			SDM("BULK", "DPSMate_VoteSuccess"..DPSMate.SYNCVERSION, self.synckey, "RAID")
 			sKey = DPSMate.SYNCVERSION..self.synckey
 			Execute = {}
 			for cat, val in pairs(important) do
@@ -215,7 +215,7 @@ function DPSMate.Sync:CountVote()
 			local num = GetNumRaidMembers()
 			if num > 0 then
 				for i=1, num-1 do
-					SDM("DPSMate_SyncTimer"..DPSMate.SYNCVERSION, UnitName("raid"..i)..","..(ceil(i/8)*30 - 30)..",", "RAID")
+					SDM("NORMAL", "DPSMate_SyncTimer"..DPSMate.SYNCVERSION, UnitName("raid"..i)..","..(ceil(i/8)*30 - 30)..",", "RAID")
 				end
 			end
 			DB.MainUpdate = ceil(num/8)*30 - 30
@@ -229,7 +229,7 @@ function DPSMate.Sync:DismissVote(elapsed)
 	if voteStarter then
 		voteTime=voteTime+elapsed
 		if voteTime>=30 then
-			SDM("DPSMate_VoteFail"..DPSMate.SYNCVERSION, nil, "RAID")
+			SDM("BULK", "DPSMate_VoteFail"..DPSMate.SYNCVERSION, nil, "RAID")
 			voteStarter = false
 			voteCount = 1
 			voteTime = 0
@@ -295,7 +295,7 @@ function DPSMate.Sync:CountParticipants()
 end
 
 function DPSMate.Sync:Participate()
-	SDM("DPSMate_Participate"..DPSMate.SYNCVERSION, nil, "RAID")
+	SDM("NORMAL", "DPSMate_Participate"..DPSMate.SYNCVERSION, nil, "RAID")
 end
 
 function DPSMate.Sync:ReceiveStartVote() 
@@ -309,7 +309,7 @@ end
 
 function DPSMate.Sync:AbortVote()
 	if IsPartyLeader() or IsRaidOfficer() then
-		SDM("DPSMate_AbortVote"..DPSMate.SYNCVERSION, "NaN", "RAID")
+		SDM("BULK", "DPSMate_AbortVote"..DPSMate.SYNCVERSION, "NaN", "RAID")
 		DPSMate:SendMessage(DPSMate.L["resetaborted"])
 	end
 end
@@ -326,12 +326,12 @@ function DPSMate.Sync:HelloWorld()
 	if (GetTime()-bc)>=3 then
 		bc = GetTime()
 		am = 1
-		SDM("DPSMate_HelloWorld", "NaN", "RAID")
+		SDM("BULK", "DPSMate_HelloWorld", "NaN", "RAID")
 	end
 end
 
 function DPSMate.Sync:GreetBack()
-	SDM("DPSMate_Greet", DPSMate.SYNCVERSION, "RAID")
+	SDM("BULK", "DPSMate_Greet", DPSMate.SYNCVERSION, "RAID")
 end
 
 local old = 0
@@ -963,7 +963,7 @@ DPSMate.Parser.UseAction = function(slot, checkCursor, onSelf)
 	local aura = DPSMate_TooltipTextLeft1:GetText()
 	local target = GetTargetP()
 	if aura and target and (DPSMate.Sync.OverTimeDispels[aura] or DPSMate.Sync.AbsorbAbilities[aura] or DPSMate.Sync.OtherAbilities[aura]) and not DPSMate.Parser.SendSpell[aura] then
-		SDM("DPSMate"..sKey, aura..","..target..",", "RAID")
+		SDM("ALERT", "DPSMate"..sKey, aura..","..target..",", "RAID")
 		DPSMate.Parser.SendSpell[aura] = true
 	end
 	if aura then
@@ -982,7 +982,7 @@ local oldCastSpellByName = CastSpellByName
 DPSMate.Parser.CastSpellByName = function(spellName, onSelf)
 	local target = GetTargetP()
 	if target and (DPSMate.Sync.OverTimeDispels[spellName] or DPSMate.Sync.AbsorbAbilities[spellName] or DPSMate.Sync.OtherAbilities[spellName]) and not DPSMate.Parser.SendSpell[spellName] then 
-		SDM("DPSMate"..sKey, spellName..","..target..",", "RAID")
+		SDM("ALERT", "DPSMate"..sKey, spellName..","..target..",", "RAID")
 		DPSMate.Parser.SendSpell[spellName] = true
 	end
 	local time = GetTime()
@@ -1000,7 +1000,7 @@ DPSMate.Parser.CastSpell = function(spellID, spellbookType)
 	local spellName, spellRank = GetSpellName(spellID, spellbookType)
 	local target = GetTargetP()
 	if target and (DPSMate.Sync.OverTimeDispels[spellName] or DPSMate.Sync.AbsorbAbilities[spellName] or DPSMate.Sync.OtherAbilities[spellName]) and not DPSMate.Parser.SendSpell[spellName] then 
-		SDM("DPSMate"..sKey, spellName..","..target..",", "RAID")
+		SDM("ALERT", "DPSMate"..sKey, spellName..","..target..",", "RAID")
 		DPSMate.Parser.SendSpell[spellName] = true
 	end
 	local time = GetTime()

--- a/DPSMate/DPSMate_Sync.lua
+++ b/DPSMate/DPSMate_Sync.lua
@@ -14,7 +14,6 @@ local strgfind = string.gfind
 local tinsert = table.insert
 local tremove = table.remove
 local tnbr = tonumber
-local SDM = ChatThrottleLib.SendAddonMessage
 local func = function(c) tinsert(t,c) end
 local LastMouseover = nil
 local DB = DPSMate.DB
@@ -51,6 +50,9 @@ local trivial, lesstrivial, important, Execute = nil, nil, nil, {}
 local strsub = string.sub
 local strfind = string.find
 local UnitAffectingCombat = UnitAffectingCombat
+local SDM = function(prio, prefix, text, chattype)
+	ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype)
+end
 
 -- Beginn Functions
 

--- a/DPSMate/libs/ChatThrottleLib.lua
+++ b/DPSMate/libs/ChatThrottleLib.lua
@@ -1,0 +1,464 @@
+--
+-- ChatThrottleLib by Mikk
+--
+-- Manages AddOn chat output to keep player from getting kicked off.
+--
+-- ChatThrottleLib.SendChatMessage/.SendAddonMessage functions that accept 
+-- a Priority ("BULK", "NORMAL", "ALERT") as well as prefix for SendChatMessage.
+--
+-- Priorities get an equal share of available bandwidth when fully loaded.
+-- Communication channels are separated on extension+chattype+destination and
+-- get round-robinned. (Destination only matters for whispers and channels,
+-- obviously)
+--
+-- Will install hooks for SendChatMessage and SendAdd[Oo]nMessage to measure
+-- bandwidth bypassing the library and use less bandwidth itself.
+--
+--
+-- Fully embeddable library. Just copy this file into your addon directory,
+-- add it to the .toc, and it's done.
+--
+-- Can run as a standalone addon also, but, really, just embed it! :-)
+--
+
+local CTL_VERSION = 13
+
+local MAX_CPS = 800			  -- 2000 seems to be safe if NOTHING ELSE is happening. let's call it 800.
+local MSG_OVERHEAD = 40		-- Guesstimate overhead for sending a message; source+dest+chattype+protocolstuff
+
+local BURST = 4000				-- WoW's server buffer seems to be about 32KB. 8KB should be safe, but seen disconnects on _some_ servers. Using 4KB now.
+
+local MIN_FPS = 20				-- Reduce output CPS to half (and don't burst) if FPS drops below this value
+
+if(ChatThrottleLib and ChatThrottleLib.version>=CTL_VERSION) then
+	-- There's already a newer (or same) version loaded. Buh-bye.
+	return;
+end
+
+
+
+if(not ChatThrottleLib) then
+	ChatThrottleLib = {}
+end
+
+local ChatThrottleLib = ChatThrottleLib
+local strlen = strlen
+local setmetatable = setmetatable
+local getn = getn
+local tremove = tremove
+local tinsert = tinsert
+local tostring = tostring
+local GetTime = GetTime
+local format = format
+
+ChatThrottleLib.version=CTL_VERSION;
+
+
+-----------------------------------------------------------------------
+-- Double-linked ring implementation
+
+local Ring = {}
+local RingMeta = { __index=Ring }
+
+function Ring:New()
+	local ret = {}
+	setmetatable(ret, RingMeta)
+	return ret;
+end
+
+function Ring:Add(obj)	-- Append at the "far end" of the ring (aka just before the current position)
+	if(self.pos) then
+		obj.prev = self.pos.prev;
+		obj.prev.next = obj;
+		obj.next = self.pos;
+		obj.next.prev = obj;
+	else
+		obj.next = obj;
+		obj.prev = obj;
+		self.pos = obj;
+	end
+end
+
+function Ring:Remove(obj)
+	obj.next.prev = obj.prev;
+	obj.prev.next = obj.next;
+	if(self.pos == obj) then
+		self.pos = obj.next;
+		if(self.pos == obj) then
+			self.pos = nil;
+		end
+	end
+end
+
+
+
+-----------------------------------------------------------------------
+-- Recycling bin for pipes (kept in a linked list because that's 
+-- how they're worked with in the rotating rings; just reusing members)
+
+ChatThrottleLib.PipeBin = { count=0 }
+
+function ChatThrottleLib.PipeBin:Put(pipe)
+	for i=getn(pipe),1,-1 do
+		tremove(pipe, i);
+	end
+	pipe.prev = nil;
+	pipe.next = self.list;
+	self.list = pipe;
+	self.count = self.count+1;
+end
+
+function ChatThrottleLib.PipeBin:Get()
+	if(self.list) then
+		local ret = self.list;
+		self.list = ret.next;
+		ret.next=nil;
+		self.count = self.count - 1;
+		return ret;
+	end
+	return {};
+end
+
+function ChatThrottleLib.PipeBin:Tidy()
+	if(self.count < 25) then
+		return;
+	end
+		
+	if(self.count > 100) then
+		n=self.count-90;
+	else
+		n=10;
+	end
+	for i=2,n do
+		self.list = self.list.next;
+	end
+	local delme = self.list;
+	self.list = self.list.next;
+	delme.next = nil;
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Recycling bin for messages
+
+ChatThrottleLib.MsgBin = {}
+
+function ChatThrottleLib.MsgBin:Put(msg)
+	msg.text = nil;
+	tinsert(self, msg);
+end
+
+function ChatThrottleLib.MsgBin:Get()
+	local ret = tremove(self, getn(self));
+	if(ret) then return ret; end
+	return {};
+end
+
+function ChatThrottleLib.MsgBin:Tidy()
+	if(getn(self)<50) then
+		return;
+	end
+	if(getn(self)>150) then	 -- "can't happen" but ...
+		for n=getn(self),120,-1 do
+			tremove(self,n);
+		end
+	else
+		for n=getn(self),getn(self)-20,-1 do
+			tremove(self,n);
+		end
+	end
+end
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib:Init
+-- Initialize queues, set up frame for OnUpdate, etc
+
+
+function ChatThrottleLib:Init()	
+	
+	-- Set up queues
+	if(not self.Prio) then
+		self.Prio = {}
+		self.Prio["ALERT"] = { ByName={}, Ring = Ring:New(), avail=0 };
+		self.Prio["NORMAL"] = { ByName={}, Ring = Ring:New(), avail=0 };
+		self.Prio["BULK"] = { ByName={}, Ring = Ring:New(), avail=0 };
+	end
+	
+	-- v4: total send counters per priority
+	for _,Prio in pairs(self.Prio) do
+		Prio.nTotalSent = Prio.nTotalSent or 0;
+	end
+	
+	self.avail = self.avail or 0;							-- v5
+	self.nTotalSent = self.nTotalSent or 0;		-- v5
+
+	
+	-- Set up a frame to get OnUpdate events
+	if(not self.Frame) then
+		self.Frame = CreateFrame("Frame");
+		self.Frame:Hide();
+	end
+	self.Frame.Show = self.Frame.Show; -- cache for speed
+	self.Frame.Hide = self.Frame.Hide; -- cache for speed
+	self.Frame:SetScript("OnUpdate", self.OnUpdate);
+	self.Frame:SetScript("OnEvent", self.OnEvent);	-- v11: Monitor P_E_W so we can throttle hard for a few seconds
+	self.Frame:RegisterEvent("PLAYER_ENTERING_WORLD");
+	self.OnUpdateDelay=0;
+	self.LastAvailUpdate=GetTime();
+	self.HardThrottlingBeginTime=GetTime();	-- v11: Throttle hard for a few seconds after startup
+	
+	-- Hook SendChatMessage and SendAddonMessage so we can measure unpiped traffic and avoid overloads (v7)
+	if(not self.ORIG_SendChatMessage) then
+		--SendChatMessage
+		self.ORIG_SendChatMessage = SendChatMessage;
+		SendChatMessage = function(a1,a2,a3,a4) return ChatThrottleLib.Hook_SendChatMessage(a1,a2,a3,a4); end
+		--SendAdd[Oo]nMessage
+		if(SendAddonMessage or SendAddOnMessage) then -- v10: don't pretend like it doesn't exist if it doesn't!
+			self.ORIG_SendAddonMessage = SendAddonMessage or SendAddOnMessage;
+			SendAddonMessage = function(a1,a2,a3) return ChatThrottleLib.Hook_SendAddonMessage(a1,a2,a3); end
+			if(SendAddOnMessage) then		-- in case Slouken changes his mind...
+				SendAddOnMessage = SendAddonMessage;
+			end
+		end
+	end
+	self.nBypass = 0;
+end
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib.Hook_SendChatMessage / .Hook_SendAddonMessage
+function ChatThrottleLib.Hook_SendChatMessage(text, chattype, language, destination)
+	local self = ChatThrottleLib;
+	local size = strlen(tostring(text or "")) + strlen(tostring(chattype or "")) + strlen(tostring(destination or "")) + 40;
+	self.avail = self.avail - size;
+	self.nBypass = self.nBypass + size;
+	return self.ORIG_SendChatMessage(text, chattype, language, destination);
+end
+function ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype)
+	local self = ChatThrottleLib;
+	local size = strlen(tostring(text or "")) + strlen(tostring(chattype or "")) + strlen(tostring(prefix or "")) + 40;
+	self.avail = self.avail - size;
+	self.nBypass = self.nBypass + size;
+	return self.ORIG_SendAddonMessage(prefix, text, chattype);
+end
+
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib:UpdateAvail
+-- Update self.avail with how much bandwidth is currently available
+
+function ChatThrottleLib:UpdateAvail()
+	local now = GetTime();
+	local newavail = MAX_CPS * (now-self.LastAvailUpdate);
+
+	if(now - self.HardThrottlingBeginTime < 5) then
+		-- First 5 seconds after startup/zoning: VERY hard clamping to avoid irritating the server rate limiter, it seems very cranky then
+		self.avail = min(self.avail + (newavail*0.1), MAX_CPS*0.5);
+	elseif(GetFramerate()<MIN_FPS) then		-- GetFrameRate call takes ~0.002 secs
+		newavail = newavail * 0.5;
+		self.avail = min(MAX_CPS, self.avail + newavail);
+		self.bChoking = true;		-- just for stats
+	else
+		self.avail = min(BURST, self.avail + newavail);
+		self.bChoking = false;
+	end
+	
+	self.avail = max(self.avail, 0-(MAX_CPS*2));	-- Can go negative when someone is eating bandwidth past the lib. but we refuse to stay silent for more than 2 seconds; if they can do it, we can.
+	self.LastAvailUpdate = now;
+	
+	return self.avail;
+end
+
+
+-----------------------------------------------------------------------
+-- Despooling logic
+
+function ChatThrottleLib:Despool(Prio)
+	local ring = Prio.Ring;
+	while(ring.pos and Prio.avail>ring.pos[1].nSize) do
+		local msg = tremove(Prio.Ring.pos, 1);
+		if(not Prio.Ring.pos[1]) then
+			local pipe = Prio.Ring.pos;
+			Prio.Ring:Remove(pipe);
+			Prio.ByName[pipe.name] = nil;
+			self.PipeBin:Put(pipe);
+		else
+			Prio.Ring.pos = Prio.Ring.pos.next;
+		end
+		Prio.avail = Prio.avail - msg.nSize;
+		msg.f(msg[1], msg[2], msg[3], msg[4]);
+		Prio.nTotalSent = Prio.nTotalSent + msg.nSize;
+		self.MsgBin:Put(msg);
+	end
+end
+
+
+function ChatThrottleLib.OnEvent()
+	-- v11: We know that the rate limiter is touchy after login. Assume that it's touch after zoning, too.
+	self = ChatThrottleLib;
+	if(event == "PLAYER_ENTERING_WORLD") then
+		self.HardThrottlingBeginTime=GetTime();	-- Throttle hard for a few seconds after zoning
+		self.avail = 0;
+	end
+end
+
+
+function ChatThrottleLib.OnUpdate()
+	self = ChatThrottleLib;
+	
+	self.OnUpdateDelay = self.OnUpdateDelay + arg1;
+	if(self.OnUpdateDelay < 0.08) then
+		return;
+	end
+	self.OnUpdateDelay = 0;
+	
+	self:UpdateAvail();
+	
+	if(self.avail<0) then
+		return; -- argh. some bastard is spewing stuff past the lib. just bail early to save cpu.
+	end
+
+	-- See how many of or priorities have queued messages
+	local n=0;
+	for prioname,Prio in pairs(self.Prio) do
+		if(Prio.Ring.pos or Prio.avail<0) then 
+			n=n+1; 
+		end
+	end
+	
+	-- Anything queued still?
+	if(n<1) then
+		-- Nope. Move spillover bandwidth to global availability gauge and clear self.bQueueing
+		for prioname,Prio in pairs(self.Prio) do
+			self.avail = self.avail + Prio.avail;
+			Prio.avail = 0;
+		end
+		self.bQueueing = false;
+		self.Frame:Hide();
+		return;
+	end
+	
+	-- There's stuff queued. Hand out available bandwidth to priorities as needed and despool their queues
+	local avail= self.avail/n;
+	self.avail = 0;
+	
+	for prioname,Prio in pairs(self.Prio) do
+		if(Prio.Ring.pos or Prio.avail<0) then
+			Prio.avail = Prio.avail + avail;
+			if(Prio.Ring.pos and Prio.avail>Prio.Ring.pos[1].nSize) then
+				self:Despool(Prio);
+			end
+		end
+	end
+
+	-- Expire recycled tables if needed	
+	self.MsgBin:Tidy();
+	self.PipeBin:Tidy();
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Spooling logic
+
+
+function ChatThrottleLib:Enqueue(prioname, pipename, msg)
+	local Prio = self.Prio[prioname];
+	local pipe = Prio.ByName[pipename];
+	if(not pipe) then
+		self.Frame:Show();
+		pipe = self.PipeBin:Get();
+		pipe.name = pipename;
+		Prio.ByName[pipename] = pipe;
+		Prio.Ring:Add(pipe);
+	end
+	
+	tinsert(pipe, msg);
+	
+	self.bQueueing = true;
+end
+
+
+
+function ChatThrottleLib:SendChatMessage(prio, prefix,   text, chattype, language, destination)
+	if(not (self and prio and text and self.Prio[prio] ) ) then
+		error('Usage: ChatThrottleLib:SendChatMessage("{BULK||NORMAL||ALERT}", "prefix" or nil, "text"[, "chattype"[, "language"[, "destination"]]]', 2);
+	end
+	
+	prefix = prefix or tostring(this);		-- each frame gets its own queue if prefix is not given
+	
+	local nSize = strlen(text) + MSG_OVERHEAD;
+	
+	-- Check if there's room in the global available bandwidth gauge to send directly
+	if(not self.bQueueing and nSize < self:UpdateAvail()) then
+		self.avail = self.avail - nSize;
+		self.ORIG_SendChatMessage(text, chattype, language, destination);
+		self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize;
+		return;
+	end
+	
+	-- Message needs to be queued
+	msg=self.MsgBin:Get();
+	msg.f=self.ORIG_SendChatMessage
+	msg[1]=text;
+	msg[2]=chattype or "SAY";
+	msg[3]=language;
+	msg[4]=destination;
+	msg.n = 4
+	msg.nSize = nSize;
+
+	self:Enqueue(prio, format("%s/%s/%s", prefix, chattype, destination or ""), msg);
+end
+
+
+function ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype)
+	if(not (self and prio and prefix and text and chattype and self.Prio[prio] ) ) then
+		error('Usage: ChatThrottleLib:SendAddonMessage("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype")', 0);
+	end
+	
+	local nSize = strlen(prefix) + 1 + strlen(text) + MSG_OVERHEAD;
+	
+	-- Check if there's room in the global available bandwidth gauge to send directly
+	if(not self.bQueueing and nSize < self:UpdateAvail()) then
+		self.avail = self.avail - nSize;
+		self.ORIG_SendAddonMessage(prefix, text, chattype);
+		self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize;
+		return;
+	end
+	
+	-- Message needs to be queued
+	msg=self.MsgBin:Get();
+	msg.f=self.ORIG_SendAddonMessage;
+	msg[1]=prefix;
+	msg[2]=text;
+	msg[3]=chattype;
+	msg.n = 3
+	msg.nSize = nSize;
+	
+	self:Enqueue(prio, format("%s/%s", prefix, chattype), msg);
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Get the ball rolling!
+
+ChatThrottleLib:Init();
+
+--[[ WoWBench debugging snippet
+if(WOWB_VER) then
+	local function SayTimer()
+		print("SAY: "..GetTime().." "..arg1);
+	end
+	ChatThrottleLib.Frame:SetScript("OnEvent", SayTimer);
+	ChatThrottleLib.Frame:RegisterEvent("CHAT_MSG_SAY");
+end
+]]
+
+


### PR DESCRIPTION
Embed and use ChatThrottleLib to manage both addon and chat communication.   
_(same library is hard-embedded in AceComm-2.0, but the other facilities of AceComm-2.0 are not needed here)_

Also re-adds the combatlog extension to 200y at an appropriate event to avoid initialization error.