### PR TITLE
DPSMate_Debug tweak

### DIFF
--- a/DPSMate_Debug/DPSMate_Debug.lua
+++ b/DPSMate_Debug/DPSMate_Debug.lua
@@ -10,7 +10,7 @@ DPSMate.Modules.Debug.Cache = setmetatable({},
 DPSMate.Modules.Debug.FRAMES = {}
 
 function DPSMate.Modules.Debug:Store(msg)
-  local earliest = self.Cache[msg]
+  return self.Cache[msg]
 end
 
 function DPSMate.Modules.Debug:Out()


### PR DESCRIPTION
Return from DPSMate_Debug (as intended) so the short circuit on the main addon stores the warning output for logout and doesn't also print it on the chatframe if the user has the Debug module enabled.