### PR TITLE
Fixes edge case for UnitName("player") #225

### DIFF
--- a/DPSMate/DPSMate_Parser.lua
+++ b/DPSMate/DPSMate_Parser.lua
@@ -493,7 +493,7 @@ local GetPlayerBuff = GetPlayerBuff
 -- Begin Functions
 
 function DPSMate.Parser:OnLoad()
-	self.player = UnitName("player")
+	self.player, self.realm = UnitName("player")
 	_,playerclass = UnitClass("player")
 	DPSMate.DB:BuildUser(self.player, strlower(playerclass))
 	DPSMateUser[self.player][2] = strlower(playerclass)

--- a/DPSMate/DPSMate_Sync.lua
+++ b/DPSMate/DPSMate_Sync.lua
@@ -4,7 +4,7 @@
 -- Fails
 
 -- Local Variables
-local player = UnitName("player")
+local player = (UnitName("player"))
 local _, playerclass = UnitClass("player")
 local pid = 0
 local time, iterator, voteStarter = 0, 1, false


### PR DESCRIPTION
Work Work

Fixes #225 

This seemed to resolve the issue so far for us.

Make sure you go to WTF/Account/Account Name/SavedVariables/ Folder and delete the DPSMate.lua and DPSMate.lua.bak files